### PR TITLE
Remove unnecessary local listening

### DIFF
--- a/servers/master_server_protocol.go
+++ b/servers/master_server_protocol.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"net"
 )
 
 // Defines a server region.
@@ -61,7 +60,7 @@ func (query serverListQuery) bytes() []byte {
 // Use the generator concurrency pattern to stream the parsed servers over an established channel.
 //
 // The servers channel will be used to stream each newly read batch of Server objects. The error channel will serve
-// as a "control" channel to indicate that an error has occurred at some point during the operation. To indicate that 
+// as a "control" channel to indicate that an error has occurred at some point during the operation. To indicate that
 // there are no more servers to be streamed, a ChannelExhausted error will be sent on the error channel.
 //
 // A timeout value is required. For example: 500ms. See time.ParseDuration for more information.
@@ -79,11 +78,7 @@ func GetServerList(masterServer string, region ServerRegion, filter string, time
 		defer outboundConnection.Close()
 
 		// Establish an inbound connection to receive the master server replies
-		inboundConnection, listenError := listen(outboundConnection.LocalAddr().(*net.UDPAddr))
-		if listenError != nil {
-			error <- listenError
-			return
-		}
+		inboundConnection := outboundConnection
 		defer inboundConnection.Close()
 
 		deadlineError := setReadDeadline(inboundConnection, timeout)

--- a/servers/server_query_protocol.go
+++ b/servers/server_query_protocol.go
@@ -271,10 +271,7 @@ func openConnections(server string, timeout string) (outboundConnection *net.UDP
 		return
 	}
 
-	inboundConnection, error = listen(outboundConnection.LocalAddr().(*net.UDPAddr))
-	if error != nil {
-		return
-	}
+	inboundConnection = outboundConnection
 
 	error = setReadDeadline(inboundConnection, timeout)
 	if error != nil {


### PR DESCRIPTION
`GetServerList`, `GetServerInfo` and `GetPlayerInfo` functions fail with `address already in use`.

```
--- FAIL: TestGetServerList (0.00 seconds)
    master_server_protocol_test.go:23: Error during server list fecthing: listen udp 192.168.1.128:51548: address already in use
--- FAIL: TestGetServerInfo (0.00 seconds)
    server_query_protocol_test.go:20: Error during server info fecthing: listen udp 192.168.1.128:57259: address already in use
--- FAIL: TestGetPlayerInfo (0.00 seconds)
    server_query_protocol_test.go:75: Error during player info fecthing: listen udp 192.168.1.128:41032: address already in use
```

This is caused by listening on a local address that's already been bound by `connect()`, therefore, I removed that. This solved the problem. Tests still do fail, but that's happening with due to issues with remote servers. Though this should warrant creating another issue.
